### PR TITLE
Simplification of interface for Endianness

### DIFF
--- a/src/DotNet.Plus.Test/BasicType/BitFieldTests.cs
+++ b/src/DotNet.Plus.Test/BasicType/BitFieldTests.cs
@@ -72,5 +72,13 @@ namespace DotNet.Plus.Test.BasicType
             Should.Throw<ArgumentOutOfRangeException>(() => new BitField<byte>(0b0101_1100));
         }
 
+        [TestMethod]
+        public void BitFieldSameContainerTest()
+        {
+            var test = new BitField<byte>(4, startBitOffset: 0);
+            test.Bitmask.ShouldBe<byte>(0b1111_0000);
+
+        }
+
     }
 }

--- a/src/DotNet.Plus/Endian/Endianness.cs
+++ b/src/DotNet.Plus/Endian/Endianness.cs
@@ -167,12 +167,14 @@ namespace DotNet.Plus.Endian
         /// </summary>
         /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
         /// <param name="numBytes">The number of bytes, up to a maximum of 8, to write to the buffer.</param>
-        /// <param name="buffer">The destination buffer identified by the given ArraySegment.  There must be at least numBytes bytes
-        /// of space available in the buffer.</param>
+        /// <param name="buffer">The destination buffer identified by the given IList{Byte} which can be an ArraySegment, Array, etc.  There
+        /// must be at least numBytes bytes of space available in the buffer.</param>
+        /// <param name="startOffset">Starting offset from start of the given buffer</param>
         /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
         /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static ArraySegment<byte> ToBuffer(this UInt64 value, int numBytes, ArraySegment<byte> buffer, EndianFormat endian = EndianFormat.Big)
+        public static TList ToBuffer<TList>(this UInt64 value, int numBytes, TList buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big)
+            where TList : IList<byte>
         {
             if( numBytes == 0 )
                 return buffer;
@@ -201,12 +203,12 @@ namespace DotNet.Plus.Endian
             //    7     buffer[0]     56     0xFF00000000000000   buffer[7]
             var bitMask = (UInt64)0xFF;   // This needs to be cast or it will default to a smaller size
             var shift = 0;
-            var bufferIndex = buffer.Offset + (endian == EndianFormat.Big ? numBytes - 1 : 0);
+            var bufferIndex = startOffset + (endian == EndianFormat.Big ? numBytes - 1 : 0);
             var bufferIndexInc = endian == EndianFormat.Big ? -1 : 1;
             for( var index = 0; index < numBytes; index += 1, bitMask <<= BitsInByte, shift += BitsInByte, bufferIndex += bufferIndexInc )
             {
                 UInt64 maskedData = value & bitMask;
-                buffer.Array[bufferIndex] = (byte)(maskedData >> shift);
+                buffer[bufferIndex] = (byte)(maskedData >> shift);
             }
 
             return buffer;

--- a/src/DotNet.Plus/Endian/Endianness16Bit.cs
+++ b/src/DotNet.Plus/Endian/Endianness16Bit.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using DotNet.Plus.BasicType;
 
 namespace DotNet.Plus.Endian
 {
@@ -19,31 +18,19 @@ namespace DotNet.Plus.Endian
         /// <exception cref="ArgumentOutOfRangeException">If unable to read data from buffer because it's too small, etc</exception>
         public static UInt16 ToUInt16(this IReadOnlyList<byte> buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
             (UInt16)ToUInt64(buffer, sizeof(UInt16), startOffset, signExtend: false, endian);
-
+        
         /// <summary>
         /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
         /// </summary>
         /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer identified by the given ArraySegment.  There must be at least 2 bytes
-        /// of space available in the buffer.</param>
+        /// <param name="buffer">The destination buffer.  There must be at least 2 bytes of space available in the buffer.  The buffer
+        /// can be any IList{byte} such as an Array or ArraySegment.</param>
+        /// <param name="startOffset">Starting from this optional index</param>
         /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
         /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static ArraySegment<byte> ToBuffer(this UInt16 value, ArraySegment<byte> buffer, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, sizeof(UInt16), buffer, endian);
-
-        /// <summary>
-        /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
-        /// </summary>
-        /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer.  There must be at least 2 bytes of space available in the buffer
-        /// from the specified offset.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to write</param>
-        /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
-        /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static byte[] ToBuffer(this UInt16 value, byte[] buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, buffer.ToArraySegment(startOffset), endian).Array;
+        public static TList ToBuffer<TList>(this UInt16 value, TList buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big)
+            where TList : IList<byte> => ToBuffer(value, sizeof(UInt16), buffer, startOffset, endian);
 
         /// <summary>
         /// Writes the value into a newly allocated buffer (byte array) using the specified <see cref="Endianness"/>.
@@ -68,32 +55,20 @@ namespace DotNet.Plus.Endian
         /// <returns>The value read from the buffer using the specified endianness formatted as a C# value.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to read data from buffer because it's too small, etc</exception>
         public static Int16 ToInt16(this IReadOnlyList<byte> buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
-            (Int16)ToUInt64(buffer, sizeof(Int16), startOffset, signExtend: true, endian);  
+            (Int16)ToUInt64(buffer, sizeof(Int16), startOffset, signExtend: true, endian);
 
         /// <summary>
         /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
         /// </summary>
         /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer identified by the given ArraySegment.  There must be at least 2 bytes
-        /// of space available in the buffer.</param>
+        /// <param name="buffer">The destination buffer.  There must be at least 2 bytes of space available in the buffer.  The buffer
+        /// can be any IList{byte} such as an Array or ArraySegment.</param>
+        /// <param name="startOffset">Starting from this optional index</param>
         /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
         /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static ArraySegment<byte> ToBuffer(this Int16 value, ArraySegment<byte> buffer, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer((UInt64) value, sizeof(Int16), buffer, endian);
-
-        /// <summary>
-        /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
-        /// </summary>
-        /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer.  There must be at least 2 bytes of space available in the buffer
-        /// from the specified offset.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to write</param>
-        /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
-        /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static byte[] ToBuffer(this Int16 value, byte[] buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, buffer.ToArraySegment(startOffset), endian).Array;
+        public static TList ToBuffer<TList>(this Int16 value, TList buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big)
+            where TList : IList<byte> => ToBuffer((UInt64)value, sizeof(Int16), buffer, startOffset, endian);
 
         /// <summary>
         /// Writes the value into a newly allocated buffer (byte array) using the specified <see cref="Endianness"/>.

--- a/src/DotNet.Plus/Endian/Endianness32Bit.cs
+++ b/src/DotNet.Plus/Endian/Endianness32Bit.cs
@@ -12,8 +12,8 @@ namespace DotNet.Plus.Endian
         /// </summary>
         /// <param name="buffer">The byte buffer.  This supports a variety of data types such as byte arrays,
         /// lists, etc.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at
-        /// least 4 bytes in the buffer starting from this index.</param>
+        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at least 4 bytes in
+        /// the buffer starting from this index.</param>
         /// <param name="endian">Specifies the format, <see cref="Endianness"/>, of the value in the given buffer.</param>
         /// <returns>The value read from the buffer using the specified <see cref="Endianness"/> formatted as a C# value.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to read data from buffer because it's too small, etc</exception>
@@ -24,26 +24,14 @@ namespace DotNet.Plus.Endian
         /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
         /// </summary>
         /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer identified by the given ArraySegment.  There must be at least 4 bytes
-        /// of space available in the buffer.</param>
+        /// <param name="buffer">The destination buffer.  There must be at least 4 bytes of space available in the buffer.  The buffer
+        /// can be any IList{byte} such as an Array or ArraySegment.</param>
+        /// <param name="startOffset">Starting from this optional index</param>
         /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
         /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static ArraySegment<byte> ToBuffer(this UInt32 value, ArraySegment<byte> buffer, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, sizeof(UInt32), buffer, endian);
-
-        /// <summary>
-        /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
-        /// </summary>
-        /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer.  There must be at least 4 bytes of space available in the buffer
-        /// from the specified offset.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to write</param>
-        /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
-        /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static byte[] ToBuffer(this UInt32 value, byte[] buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, buffer.ToArraySegment(startOffset), endian).Array;
+        public static TList ToBuffer<TList>(this UInt32 value, TList buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big)
+            where TList : IList<byte> => ToBuffer((UInt64)value, sizeof(UInt32), buffer, startOffset, endian);
 
         /// <summary>
         /// Writes the value into a newly allocated buffer (byte array) using the specified <see cref="Endianness"/>.
@@ -62,8 +50,8 @@ namespace DotNet.Plus.Endian
         /// </summary>
         /// <param name="buffer">The byte buffer.  This supports a variety of data types such as byte arrays,
         /// lists, etc.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at
-        /// least 4 bytes in the buffer starting from this index.</param>
+        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at least 4 bytes in the
+        /// buffer starting from this index.</param>
         /// <param name="endian">Specifies the format, <see cref="Endianness"/>, of the value in the given buffer.</param>
         /// <returns>The value read from the buffer using the specified endianness formatted as a C# value.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to read data from buffer because it's too small, etc</exception>
@@ -74,26 +62,14 @@ namespace DotNet.Plus.Endian
         /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
         /// </summary>
         /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer identified by the given ArraySegment.  There must be at least 4 bytes
-        /// of space available in the buffer.</param>
+        /// <param name="buffer">The destination buffer.  There must be at least 4 bytes of space available in the buffer.  The buffer
+        /// can be any IList{byte} such as an Array or ArraySegment.</param>
+        /// <param name="startOffset">Starting from this optional index</param>
         /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
         /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static ArraySegment<byte> ToBuffer(this Int32 value, ArraySegment<byte> buffer, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer((UInt64)value, sizeof(Int32), buffer, endian);
-
-        /// <summary>
-        /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
-        /// </summary>
-        /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer.  There must be at least 4 bytes of space available in the buffer
-        /// from the specified offset.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to write</param>
-        /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
-        /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static byte[] ToBuffer(this Int32 value, byte[] buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, buffer.ToArraySegment(startOffset), endian).Array;
+        public static TList ToBuffer<TList>(this Int32 value, TList buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big)
+            where TList : IList<byte> => ToBuffer((UInt64)value, sizeof(Int32), buffer, startOffset, endian);
 
         /// <summary>
         /// Writes the value into a newly allocated buffer (byte array) using the specified <see cref="Endianness"/>.

--- a/src/DotNet.Plus/Endian/Endianness64Bit.cs
+++ b/src/DotNet.Plus/Endian/Endianness64Bit.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using DotNet.Plus.BasicType;
 
 namespace DotNet.Plus.Endian
 {
@@ -12,8 +11,8 @@ namespace DotNet.Plus.Endian
         /// </summary>
         /// <param name="buffer">The byte buffer.  This supports a variety of data types such as byte arrays,
         /// lists, etc.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at
-        /// least 4 bytes in the buffer starting from this index.</param>
+        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at least 8 bytes in the
+        /// buffer starting from this index.</param>
         /// <param name="endian">Specifies the format, <see cref="Endianness"/>, of the value in the given buffer.</param>
         /// <returns>The value read from the buffer using the specified <see cref="Endianness"/> formatted as a C# value.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to read data from buffer because it's too small, etc</exception>
@@ -24,26 +23,14 @@ namespace DotNet.Plus.Endian
         /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
         /// </summary>
         /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer identified by the given ArraySegment.  There must be at least 4 bytes
-        /// of space available in the buffer.</param>
+        /// <param name="buffer">The destination buffer.  There must be at least 8 bytes of space available in the buffer.  The buffer
+        /// can be any IList{byte} such as an Array or ArraySegment.</param>
+        /// <param name="startOffset">Starting from this optional index</param>
         /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
         /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static ArraySegment<byte> ToBuffer(this UInt64 value, ArraySegment<byte> buffer, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, sizeof(UInt64), buffer, endian);
-
-        /// <summary>
-        /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
-        /// </summary>
-        /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer.  There must be at least 4 bytes of space available in the buffer
-        /// from the specified offset.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to write</param>
-        /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
-        /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static byte[] ToBuffer(this UInt64 value, byte[] buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, buffer.ToArraySegment(startOffset), endian).Array;
+        public static TList ToBuffer<TList>(this UInt64 value, TList buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big)
+            where TList : IList<byte> => ToBuffer((UInt64)value, sizeof(UInt64), buffer, startOffset, endian);
 
         /// <summary>
         /// Writes the value into a newly allocated buffer (byte array) using the specified <see cref="Endianness"/>.
@@ -62,38 +49,26 @@ namespace DotNet.Plus.Endian
         /// </summary>
         /// <param name="buffer">The byte buffer.  This supports a variety of data types such as byte arrays,
         /// lists, etc.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at
-        /// least 4 bytes in the buffer starting from this index.</param>
+        /// <param name="startOffset">The zero-based index of the starting byte to read, there must be at least 8 bytes in the
+        /// buffer starting from this index.</param>
         /// <param name="endian">Specifies the format, <see cref="Endianness"/>, of the value in the given buffer.</param>
         /// <returns>The value read from the buffer using the specified endianness formatted as a C# value.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to read data from buffer because it's too small, etc</exception>
         public static Int64 ToInt64(this IReadOnlyList<byte> buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
             (Int64)ToUInt64(buffer, sizeof(Int64), startOffset, signExtend: true, endian);
-
+        
         /// <summary>
         /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
         /// </summary>
         /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer identified by the given ArraySegment.  There must be at least 4 bytes
-        /// of space available in the buffer.</param>
+        /// <param name="buffer">The destination buffer.  There must be at least 8 bytes of space available in the buffer.  The buffer
+        /// can be any IList{byte} such as an Array or ArraySegment.</param>
+        /// <param name="startOffset">Starting from this optional index</param>
         /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
         /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
         /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static ArraySegment<byte> ToBuffer(this Int64 value, ArraySegment<byte> buffer, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer((UInt64)value, sizeof(Int64), buffer, endian);
-
-        /// <summary>
-        /// Writes the value into the given buffer using the specified <see cref="Endianness"/>.
-        /// </summary>
-        /// <param name="value">The value that is to be written to the given buffer in the specified <see cref="Endianness"/></param>
-        /// <param name="buffer">The destination buffer.  There must be at least 4 bytes of space available in the buffer
-        /// from the specified offset.</param>
-        /// <param name="startOffset">The zero-based index of the starting byte to write</param>
-        /// <param name="endian">The data will be written to the buffer in this <see cref="Endianness"/>.</param>
-        /// <returns>The passed in buffer, this allows for call chaining to other operations.</returns>
-        /// <exception cref="ArgumentOutOfRangeException">If unable to write data into the buffer</exception>
-        public static byte[] ToBuffer(this Int64 value, byte[] buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big) =>
-            ToBuffer(value, buffer.ToArraySegment(startOffset), endian).Array;
+        public static TList ToBuffer<TList>(this Int64 value, TList buffer, int startOffset = 0, EndianFormat endian = EndianFormat.Big)
+            where TList : IList<byte> => ToBuffer((UInt64)value, sizeof(Int64), buffer, startOffset, endian);
 
         /// <summary>
         /// Writes the value into a newly allocated buffer (byte array) using the specified <see cref="Endianness"/>.


### PR DESCRIPTION
We don't need separate methods that take an ArraySegment as we can just use an IList<byte>.  We also use templates so the same type passed is what's returned.